### PR TITLE
arrows in film description update

### DIFF
--- a/src/sass/components/_modalFilmDetails.scss
+++ b/src/sass/components/_modalFilmDetails.scss
@@ -175,11 +175,16 @@
     }
     &--left{
       left:-50px;
-
+      @media (max-width: 400px) {
+        left: -18px;
+      }
     }
 
     &--right {
       right: -50px;
+      @media (max-width: 400px) {
+        right: -18px;
+      }
     }
   }
 }


### PR DESCRIPTION
If screen width is smaller than 400px, arrows are moved inside the modal